### PR TITLE
Fix middleware public route list

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,15 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server"
 
 // Define public routes that don't require authentication
-const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)", "/api/webhook/clerk", "/api/test"])
+const isPublicRoute = createRouteMatcher([
+  "/",
+  "/sign-in(.*)",
+  "/sign-up(.*)",
+  "/auth/signin(.*)",
+  "/auth/signup(.*)",
+  "/api/webhook/clerk",
+  "/api/test",
+])
 
 export default clerkMiddleware((auth, req) => {
   // Protect all routes except public ones


### PR DESCRIPTION
## Summary
- allow /auth/signin and /auth/signup pages through the auth middleware

## Testing
- `pnpm lint` *(fails: command prompts to setup eslint)*
- `pnpm type-check` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_684167508e2c832f9cf3daf976199ecf