### PR TITLE
Refactor Clerk auth integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ CLERK_WEBHOOK_SECRET=your_clerk_webhook_secret
 
 Refer to the [Clerk documentation](https://clerk.com/docs) for setting up OAuth providers like Google.
 
+The app exposes `/sign-in` and `/sign-up` routes that render Clerk's authentication components. Use these pages when signing in or creating an account.
+
 
 ## 🗄️ Database Schema
 

--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -56,7 +56,7 @@ export default function AuthErrorPage() {
             <Link href="/">Back to Home</Link>
           </Button>
           <Button asChild className="bg-blue-600 hover:bg-blue-700">
-            <Link href="/auth/signin">Try Again</Link>
+            <Link href="/sign-in">Try Again</Link>
           </Button>
         </CardFooter>
       </Card>

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -32,7 +32,7 @@ export default function SignInPage() {
             },
           }}
           redirectUrl="/dashboard"
-          signUpUrl="/auth/signup"
+          signUpUrl="/sign-up"
         />
       </div>
     </div>

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -32,7 +32,7 @@ export default function SignUpPage() {
             },
           }}
           redirectUrl="/dashboard"
-          signInUrl="/auth/signin"
+          signInUrl="/sign-in"
         />
       </div>
     </div>

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,6 +1,5 @@
 import type React from "react"
-import { auth } from "@clerk/nextjs/server"
-import { redirect } from "next/navigation"
+import { auth, redirectToSignIn } from "@clerk/nextjs/server"
 import { DashboardSidebar } from "@/components/dashboard/dashboard-sidebar"
 import { TopNavbar } from "@/components/dashboard/top-navbar"
 
@@ -12,7 +11,7 @@ export default async function DashboardLayout({
   const { userId } = auth()
 
   if (!userId) {
-    redirect("/auth/signin")
+    return redirectToSignIn()
   }
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,14 +36,12 @@ export default function RootLayout({
           />
         </head>
         <body className={inter.className}>
-          <ClerkProvider>
-            <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-              <ToastProvider>
-                <Suspense>{children}</Suspense>
-              </ToastProvider>
-            </ThemeProvider>
-            <Analytics />
-          </ClerkProvider>
+          <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
+            <ToastProvider>
+              <Suspense>{children}</Suspense>
+            </ToastProvider>
+          </ThemeProvider>
+          <Analytics />
         </body>
       </html>
     </ClerkProvider>

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,8 +5,6 @@ const isPublicRoute = createRouteMatcher([
   "/",
   "/sign-in(.*)",
   "/sign-up(.*)",
-  "/auth/signin(.*)",
-  "/auth/signup(.*)",
   "/api/webhook/clerk",
   "/api/test",
 ])


### PR DESCRIPTION
## Summary
- clean up nested `ClerkProvider` and keep a single provider
- use `redirectToSignIn` in dashboard layout
- update sign in/sign up URLs and error page links
- streamline public routes for Clerk middleware
- document `/sign-in` and `/sign-up` usage

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68419c550050832f8a9e33370d907a59