### PR TITLE
Fix webpack build by self-hosting fonts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,5 @@
+@import "@fontsource/inter/400.css";
+@import "@fontsource/inter/700.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -9,6 +11,7 @@
 }
 
 body {
+  font-family: 'Inter', sans-serif;
   color: rgb(var(--foreground-rgb));
   background: linear-gradient(to bottom, transparent, rgb(var(--background-end-rgb))) rgb(var(--background-start-rgb));
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,11 @@
 import type React from "react"
 import type { Metadata } from "next"
-import { Inter } from "next/font/google"
 import "./globals.css"
 import { ClerkProvider } from "@clerk/nextjs"
 import { ThemeProvider } from "@/components/theme-provider"
 import { ToastProvider } from "@/components/ui/toast-context"
 import { Analytics } from "@vercel/analytics/react"
 import { Suspense } from "react"
-
-const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
   title: "IdeaToStartup - Dashboard",
@@ -35,7 +32,7 @@ export default function RootLayout({
             sizes="32x32"
           />
         </head>
-        <body className={inter.className}>
+        <body>
           <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
             <ToastProvider>
               <Suspense>{children}</Suspense>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@ai-sdk/openai": "latest",
     "@clerk/nextjs": "latest",
     "@emotion/is-prop-valid": "latest",
+    "@fontsource/inter": "^5.2.5",
     "@google/generative-ai": "latest",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@emotion/is-prop-valid':
         specifier: latest
         version: 1.3.1
+      '@fontsource/inter':
+        specifier: ^5.2.5
+        version: 5.2.5
       '@google/generative-ai':
         specifier: latest
         version: 0.24.1
@@ -526,6 +529,9 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@fontsource/inter@5.2.5':
+    resolution: {integrity: sha512-kbsPKj0S4p44JdYRFiW78Td8Ge2sBVxi/PIBwmih+RpSXUdvS9nbs1HIiuUSPtRMi14CqLEZ/fbk7dj7vni1Sg==}
 
   '@google/generative-ai@0.24.1':
     resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
@@ -3233,6 +3239,8 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
 
   '@floating-ui/utils@0.2.9': {}
+
+  '@fontsource/inter@5.2.5': {}
 
   '@google/generative-ai@0.24.1': {}
 


### PR DESCRIPTION
## Summary
- avoid downloading fonts from Google during builds
- use Inter fonts from `@fontsource/inter`

## Testing
- `pnpm build` *(fails: Missing publishableKey)*
- `pnpm lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_684201387120832f943fa113f08eb00c