### PR TITLE
Fix clerk auth protect call

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -12,7 +12,7 @@ const isPublicRoute = createRouteMatcher([
 export default clerkMiddleware((auth, req) => {
   // Protect all routes except public ones
   if (!isPublicRoute(req)) {
-    auth().protect()
+    auth.protect()
   }
 })
 


### PR DESCRIPTION
## Summary
- update middleware to use `auth.protect()` syntax for Clerk v5

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684209590fd8832f81fafd585be2575c